### PR TITLE
bot_instance: Allow access token credentials in addition to passwords

### DIFF
--- a/src/bot_instance.py
+++ b/src/bot_instance.py
@@ -13,11 +13,26 @@ bot_instance: botlib.Bot | None = None
 def initialize_bot():
     global bot_instance
     if bot_instance is None:
-        creds = botlib.Creds(homeserver=os.getenv('HOMESERVER'),
-                             username=os.getenv('USERNAME'),
-                             password=os.getenv('PASSWORD'))
+        username = os.getenv("USERNAME")
+        password = os.getenv("PASSWORD")
+        access_token = os.getenv("ACCESS_TOKEN")
+
+        if username and password:
+            creds = botlib.Creds(
+                homeserver=os.getenv("HOMESERVER"), username=username, password=password
+            )
+        elif username and access_token:
+            creds = botlib.Creds(
+                homeserver=os.getenv("HOMESERVER"),
+                username=username,
+                access_token=access_token,
+            )
+        else:
+            raise Exception("Neither password nor access token provided.")
+
         bot = botlib.Bot(creds)
         bot_instance = bot
+
 
 def get_bot() -> botlib.Bot:
     if bot_instance is None:


### PR DESCRIPTION
In some deployments, the bot needs to authenticate with an access token instead of the password.
The pull requests implements this using a new environment variable